### PR TITLE
Update Professional Pest Management section

### DIFF
--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -1,12 +1,12 @@
 
 import { Card, CardContent } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ReactNode } from "react";
 
 interface ImageGalleryProps {
   images: {
     src: string;
     alt: string;
-    caption?: string;
+    caption?: ReactNode;
   }[];
   columns?: number;
 }
@@ -27,8 +27,8 @@ const ImageGallery = ({ images, columns = 3 }: ImageGalleryProps) => {
               className="w-full h-auto object-cover"
             />
             {image.caption && (
-              <div className="p-4 bg-white">
-                <p className="text-sm text-gray-700">{image.caption}</p>
+              <div className="p-4 bg-white text-sm text-gray-700 space-y-2">
+                {image.caption}
               </div>
             )}
           </CardContent>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,18 +16,17 @@ const Index = () => {
     {
       src: IMAGES.technician,
       alt: "Pest Control Services",
-      caption:
-        "Our licensed technicians are trained to handle all pest situations and we offer 24/7 Emergency Support",
-    },
-    {
-      src: IMAGES.businessCard,
-      alt: "Advanced Pest Control Services Business Card",
-      caption: "Licensed by the Ministry Of Environment Ontario",
-    },
-    {
-      src: IMAGES.pestTypes,
-      alt: "Pest Types Handled",
-      caption: "We handle all types of pests including bed bugs, cockroaches, ants, and more",
+      caption: (
+        <>
+          <p>
+            Our licensed technicians are trained to handle all pest situations and we offer 24/7 Emergency Support
+          </p>
+          <ul className="list-disc pl-5 mt-2 space-y-1">
+            <li>Licensed by the Ministry Of Environment Ontario</li>
+            <li>We handle all types of pests including bed bugs, cockroaches, ants, and more</li>
+          </ul>
+        </>
+      ),
     },
   ];
 


### PR DESCRIPTION
## Summary
- show only one service image with bullet point details
- allow ImageGallery captions to accept React nodes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d38f3cf48324bf6c56ebe28f04a2