### PR TITLE
Add video modal for service showcase

### DIFF
--- a/src/components/VideoModal.tsx
+++ b/src/components/VideoModal.tsx
@@ -1,0 +1,22 @@
+import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface VideoModalProps {
+  src: string;
+  buttonText?: string;
+}
+
+const VideoModal = ({ src, buttonText = "Watch Video" }: VideoModalProps) => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button className="bg-pest-red hover:bg-pest-red/90">{buttonText}</Button>
+      </DialogTrigger>
+      <DialogContent className="p-0 max-w-3xl">
+        <video src={src} controls className="w-full h-auto rounded-md" />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default VideoModal;

--- a/src/data/media.ts
+++ b/src/data/media.ts
@@ -1,0 +1,3 @@
+export const VIDEOS = {
+  pestServices: "/lovable-uploads/pestServices.mp4",
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,8 @@ import TestimonialCard from "@/components/TestimonialCard";
 import { Button } from "@/components/ui/button";
 import { Phone, BadgeCheck } from "lucide-react";
 import { IMAGES } from "@/data/images";
+import { VIDEOS } from "@/data/media";
+import VideoModal from "@/components/VideoModal";
 import { FEATURES, HOME_SERVICES } from "@/data/content";
 
 const Index = () => {
@@ -194,6 +196,17 @@ const Index = () => {
               </Button>
             </Link>
           </div>
+        </div>
+      </section>
+
+      {/* Services Video Section */}
+      <section className="py-16">
+        <div className="container mx-auto px-4 text-center">
+          <h2 className="text-3xl font-bold mb-6">See Our Team In Action</h2>
+          <VideoModal
+            src={VIDEOS.pestServices}
+            buttonText="Watch Our Services Video"
+          />
         </div>
       </section>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import { Phone, BadgeCheck } from "lucide-react";
 import { IMAGES } from "@/data/images";
 import { VIDEOS } from "@/data/media";
-import VideoModal from "@/components/VideoModal";
 import { FEATURES, HOME_SERVICES } from "@/data/content";
 
 const Index = () => {
@@ -203,10 +202,13 @@ const Index = () => {
       <section className="py-16">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-3xl font-bold mb-6">See Our Team In Action</h2>
-          <VideoModal
-            src={VIDEOS.pestServices}
-            buttonText="Watch Our Services Video"
-          />
+          <div className="flex justify-center">
+            <video
+              src={VIDEOS.pestServices}
+              controls
+              className="w-full max-w-3xl rounded-lg shadow-lg"
+            />
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- create a `VideoModal` component using the existing dialog UI
- add a `VIDEOS` constant with the uploaded service video
- integrate a new "Services Video" section on the home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857235ac6b48324af5c36d029c494a8